### PR TITLE
build: Update ltijs dependency to use unreleased v6 branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "dotenv": "^16.6.0",
         "jsonwebtoken": "^9.0.2",
-        "ltijs": "^5.9.7",
+        "ltijs": "github:Cvmcosta/ltijs#release/v6.0",
         "ltijs-sequelize": "^2.4.4"
       },
       "devDependencies": {
@@ -2651,9 +2651,8 @@
       }
     },
     "node_modules/ltijs": {
-      "version": "5.9.7",
-      "resolved": "https://registry.npmjs.org/ltijs/-/ltijs-5.9.7.tgz",
-      "integrity": "sha512-0Hc9e5xBMSJWDidJGYVOelbe+PGKYn+xwcRKbpC2sixzL47ckOElTlBuVHm6J4DmiaPJcc42EZzE29YNrJWzaA==",
+      "version": "6.0.0-alpha.4",
+      "resolved": "git+ssh://git@github.com/Cvmcosta/ltijs.git#a04fdc2ecdc955255022886bf346d9df16cb9af1",
       "dependencies": {
         "@babel/runtime": "^7.27.1",
         "body-parser": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "dotenv": "^16.6.0",
     "jsonwebtoken": "^9.0.2",
-    "ltijs": "^5.9.7",
+    "ltijs": "github:Cvmcosta/ltijs#release/v6.0",
     "ltijs-sequelize": "^2.4.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This replaces third-party cookie auth with localstorage.